### PR TITLE
Update packages docs

### DIFF
--- a/documentation/YAML_PACKAGES_DOCS.md
+++ b/documentation/YAML_PACKAGES_DOCS.md
@@ -27,7 +27,7 @@ Add `packages: !include_dir_named packages` to the `homeassistant:` section, cre
 
 
 ## YAML Package Installation
-Sample yaml packages are included in the repository packages directory [https://github.com/custom-components/weatheralerts/packages/](https://github.com/custom-components/weatheralerts/packages/). The yaml packages currently available:
+Sample yaml packages are included in the repository packages directory [https://github.com/custom-components/weatheralerts/packages/](https://github.com/custom-components/weatheralerts/tree/master/packages). The yaml packages currently available:
 * **weatheralerts.yaml** - includes the main weatheralerts sensor platform configuration. If you already have the weatheralerts platform configured elsewhere, you won't need this.
 * **weatheralerts_1.yaml** - rename your first weatheralerts platform sensor entity ID to `sensor.weatheralerts_1` to use this yaml package which includes template sensors for up to 5 active alerts and a script and automations to handle UI notifications.
 * **weatheralerts_2.yaml** - rename your second weatheralerts platform sensor entity ID to `sensor.weatheralerts_2` to use this yaml package which includes template sensors for up to 5 active alerts and a script and automations to handle UI notifications.


### PR DESCRIPTION
GitHub has a new packages feature which has broken the link that is modified above. This just fixes that link to correct the documentation.