### PR TITLE
service_template deprecated

### DIFF
--- a/packages/weatheralerts_1.yaml
+++ b/packages/weatheralerts_1.yaml
@@ -2793,7 +2793,7 @@ script:
         data:
           notification_id: "weatheralerts_1_alert"
         ## Create a new persistant notification in the UI for a new alert
-      - service_template: >
+      - service: >
           {% if states.sensor.weatheralerts_1.state != '0' %}
             persistent_notification.create
           {% endif %}


### PR DESCRIPTION
DEPRECATED as of Home Assistant 0.115.

You can use templates directly in the service parameter, replace "service_template" with just "service".

https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-decide-which-service-to-call