### PR TITLE
Update integration for config flow and options flow and add additional data to weather alert sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,19 @@ Check the **Breaking Changes** section of this README to see if you need to manu
 
 
 
+## Reconfiguration via UI
+
+You can reconfigure the integration through the Home Assistant UI:
+
+1. Go to **Settings** > **Devices & Services**.
+2. Find the **Weather Alerts** integration and click on it.
+3. Click **Configure**.
+4. Update the **State**, **Zone**, and **County** values.
+5. Click **Save**. The integration will automatically reload.
+
 # Todo list
 - [x] Add more documentation
-- [ ] Add config flow to allow UI-based configuration (eliminate yaml-based platform configuration)
+- [x] Add config flow to allow UI-based configuration (eliminate yaml-based platform configuration)
 - [ ] Create alternative (possibly simpler) YAML package or move some template sensors into the integration
 - [ ] Add backup weather alert source for occasions when weather.gov json feed is experiencing an outage
 - [ ] Add Canadian weather alerts

--- a/custom_components/weatheralerts/__init__.py
+++ b/custom_components/weatheralerts/__init__.py
@@ -1,1 +1,43 @@
 """Custom weatheralerts integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[str] = ["sensor"]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # type: ignore[override]
+    """Set up via YAML (now deprecated)."""
+    if DOMAIN in config:
+        _LOGGER.warning(
+            "YAML configuration for Weather Alerts is deprecated; please remove it and use the UI config flow instead."
+        )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]
+    """Set up Weather Alerts from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    # Forward to platform(s)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]
+    """Unload a Weather Alerts config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and entry.entry_id in hass.data.get(DOMAIN, {}):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
+

--- a/custom_components/weatheralerts/__init__.py
+++ b/custom_components/weatheralerts/__init__.py
@@ -1,5 +1,4 @@
 """Custom weatheralerts integration."""
-
 from __future__ import annotations
 
 import logging
@@ -9,81 +8,201 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant import config_entries
 
-from .const import DOMAIN
-from .sensor import CONF_STATE, CONF_ZONE, CONF_COUNTY
+from .const import (
+    DOMAIN,
+    CONF_ZONE,
+    CONF_COUNTY,
+    CONF_ZONE_NAME,
+    CONF_NAME,
+    CONF_ENTITY_NAME,
+    CONF_MARINE_ZONES,
+    CONF_UPDATE_INTERVAL,
+    CONF_API_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_API_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[str] = ["sensor"]
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    _LOGGER.debug("weatheralerts: async_setup called")
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if entries:
+        _LOGGER.debug("weatheralerts: skipping migration, existing entries found")
+        return True
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # type: ignore[override]
-    """Set up via YAML (now deprecated)."""
-    # Migrate legacy YAML sensor platform configuration to UI config entries
     sensor_conf = config.get("sensor")
     if not sensor_conf:
         return True
-    # Normalize to list
-    if isinstance(sensor_conf, dict):
-        yaml_sensors = [sensor_conf]
-    elif isinstance(sensor_conf, list):
-        yaml_sensors = sensor_conf
-    else:
-        return True
 
+    yaml_sensors = (
+        [sensor_conf] if isinstance(sensor_conf, dict)
+        else sensor_conf if isinstance(sensor_conf, list)
+        else []
+    )
     for conf in yaml_sensors:
         if not isinstance(conf, dict) or conf.get("platform") != DOMAIN:
             continue
+
+        # Extract old keys
+        state = conf.get("state", "").upper()
+        zone = conf.get("zone", "")
+        county = conf.get("county", "")
+
+        # Convert to new codes with zero-padding as needed
+        zc = f"{state}Z{str(zone).zfill(3)}" if state and zone else ""
+        cc = f"{state}C{str(county).zfill(3)}" if state and county else ""
+
         _LOGGER.warning(
-            "YAML configuration for Weather Alerts platform is deprecated; migrating to UI config entries"
+            "weatheralerts: Migrating legacy YAML config to config entries (state=%s, zone=%s, county=%s) -> (zone=%s, county=%s)",
+            state, zone, county, zc, cc,
         )
+
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_IMPORT},
                 data={
-                    CONF_STATE: conf.get(CONF_STATE),
-                    CONF_ZONE: conf.get(CONF_ZONE),
-                    CONF_COUNTY: conf.get(CONF_COUNTY, ""),
+                    CONF_ZONE: zc,
+                    CONF_COUNTY: cc,
                 },
             )
         )
     return True
 
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    _LOGGER.debug("weatheralerts: async_setup_entry called for %s", entry.entry_id)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]
-    """Set up Weather Alerts from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    # Register update listener to reload integration on options update
-    entry.add_update_listener(_async_update_listener)
-    # Forward to platform(s)
+    _LOGGER.debug("weatheralerts: forwarding setup to platforms: %s", PLATFORMS)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug("weatheralerts: platform setup complete")
 
     return True
 
-
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update to reload the integration and update title."""
-    # Compute new title based on updated options
-    state = entry.options.get(CONF_STATE, entry.data[CONF_STATE]).strip().upper()
-    zone = entry.options.get(CONF_ZONE, entry.data[CONF_ZONE]).strip()
-    county = entry.options.get(CONF_COUNTY, entry.data.get(CONF_COUNTY, "")).strip()
-    zone_id = f"{state}Z{zone.zfill(3)}"
-    if county:
-        county_id = f"{state}C{county.zfill(3)}"
-        feed_id = f"{zone_id},{county_id}"
+    _LOGGER.debug("weatheralerts: _async_update_listener triggered for %s", entry.entry_id)
+
+    # Gather current zone and naming options, respecting blank (deletion) values
+    if CONF_ZONE in entry.options:
+        zone = entry.options[CONF_ZONE].strip()
     else:
-        feed_id = zone_id
-    title = f"NWS {feed_id}"
-    hass.config_entries.async_update_entry(entry, title=title)
-    # Reload integration to apply changes
-    await hass.config_entries.async_reload(entry.entry_id)
+        zone = entry.data.get(CONF_ZONE, "").strip()
 
+    if CONF_COUNTY in entry.options:
+        county = entry.options[CONF_COUNTY].strip()
+    else:
+        county = entry.data.get(CONF_COUNTY, "").strip()
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]
-    """Unload a Weather Alerts config entry."""
+    if CONF_MARINE_ZONES in entry.options:
+        marine_zones = entry.options[CONF_MARINE_ZONES].strip()
+    else:
+        marine_zones = entry.data.get(CONF_MARINE_ZONES, "").strip()
+
+    if CONF_NAME in entry.options:
+        name = entry.options[CONF_NAME].strip()
+    else:
+        name = entry.data.get(CONF_NAME, "").strip()
+
+    if CONF_ZONE_NAME in entry.options:
+        name = entry.options[CONF_ZONE_NAME].strip()
+    else:
+        name = entry.data.get(CONF_ZONE_NAME, "").strip()
+
+    if CONF_ENTITY_NAME in entry.options:
+        entity_name = entry.options[CONF_ENTITY_NAME].strip()
+    else:
+        entity_name = entry.data.get(CONF_ENTITY_NAME, "").strip()
+
+    update_interval = int(entry.options.get(CONF_UPDATE_INTERVAL, entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)))
+    api_timeout = int(entry.options.get(CONF_API_TIMEOUT, entry.data.get(CONF_API_TIMEOUT, DEFAULT_API_TIMEOUT)))
+
+    # Rebuild feed_id and title
+    parts = [zone] if zone else []
+    if county:
+        parts.append(county)
+    if marine_zones:
+        parts.extend(z.strip() for z in marine_zones.split(",") if z.strip())
+    feed_id = ",".join(parts)
+    title = name or f"NWS {feed_id}"
+
+    # Build the new static data dict
+    new_data: dict[str, str] = {
+        CONF_ZONE: zone,
+        CONF_COUNTY: county,
+        CONF_MARINE_ZONES: marine_zones,
+        CONF_ZONE_NAME: zone_name,
+        CONF_UPDATE_INTERVAL: update_interval,
+        CONF_API_TIMEOUT: api_timeout,
+    }
+    if name:
+        new_data[CONF_NAME] = name
+    if entity_name:
+        new_data[CONF_ENTITY_NAME] = entity_name
+
+    # Merge into options (preserve icons)
+    new_options = dict(entry.options)
+    new_options.update({
+        CONF_ZONE: zone,
+        CONF_COUNTY: county,
+        CONF_MARINE_ZONES: marine_zones,
+        CONF_ZONE_NAME: zone_name,
+        CONF_UPDATE_INTERVAL: update_interval,
+        CONF_API_TIMEOUT: api_timeout,
+    })
+    if name:
+        new_options[CONF_NAME] = name
+    if entity_name:
+        new_options[CONF_ENTITY_NAME] = entity_name
+
+    # Only update if something really changed
+    if entry.data != new_data or entry.options != new_options or entry.title != title:
+        _LOGGER.debug("weatheralerts: Updating entry data/options/title")
+        hass.config_entries.async_update_entry(
+            entry,
+            data=new_data,
+            options=new_options,
+            title=title,
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
+    else:
+        _LOGGER.debug("weatheralerts: No changes detected; skipping reload")
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    _LOGGER.debug("weatheralerts: async_unload_entry called for %s", entry.entry_id)
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok and entry.entry_id in hass.data.get(DOMAIN, {}):
-        hass.data[DOMAIN].pop(entry.entry_id)
+    if unload_ok:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        _LOGGER.debug("weatheralerts: entry removed from hass.data")
     return unload_ok
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    _LOGGER.info("weatheralerts: migrating entry %s", entry.title)
+    data = dict(entry.data)
+    version = entry.version or 1
+    migrated = False
+
+    if version < 2:
+        state = data.pop("state", None)
+        zone = data.get(CONF_ZONE)
+        county = data.get(CONF_COUNTY)
+        if state and zone and isinstance(zone, (str, int)) and len(str(zone)) <= 3:
+            new_zone = f"{state.upper()}Z{str(zone).zfill(3)}"
+            data[CONF_ZONE] = new_zone
+            _LOGGER.info("weatheralerts: migrated zone to %s", new_zone)
+            migrated = True
+        if state and county and isinstance(county, (str, int)) and len(str(county)) <= 3:
+            new_county = f"{state.upper()}C{str(county).zfill(3)}"
+            data[CONF_COUNTY] = new_county
+            _LOGGER.info("weatheralerts: migrated county to %s", new_county)
+            migrated = True
+
+    if migrated:
+        hass.config_entries.async_update_entry(entry, data=data, version=2)
+        _LOGGER.info("weatheralerts: migration complete for %s", entry.title)
+    else:
+        _LOGGER.info("weatheralerts: no migration needed for %s", entry.title)
+    return True

--- a/custom_components/weatheralerts/__init__.py
+++ b/custom_components/weatheralerts/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
+from .sensor import CONF_STATE, CONF_ZONE, CONF_COUNTY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,11 +28,30 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # type:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]
     """Set up Weather Alerts from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-
+    # Register update listener to reload integration on options update
+    entry.add_update_listener(_async_update_listener)
     # Forward to platform(s)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update to reload the integration and update title."""
+    # Compute new title based on updated options
+    state = entry.options.get(CONF_STATE, entry.data[CONF_STATE]).strip().upper()
+    zone = entry.options.get(CONF_ZONE, entry.data[CONF_ZONE]).strip()
+    county = entry.options.get(CONF_COUNTY, entry.data.get(CONF_COUNTY, "")).strip()
+    zone_id = f"{state}Z{zone.zfill(3)}"
+    if county:
+        county_id = f"{state}C{county.zfill(3)}"
+        feed_id = f"{zone_id},{county_id}"
+    else:
+        feed_id = zone_id
+    title = f"NWS {feed_id}"
+    hass.config_entries.async_update_entry(entry, title=title)
+    # Reload integration to apply changes
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # type: ignore[override]

--- a/custom_components/weatheralerts/config_flow.py
+++ b/custom_components/weatheralerts/config_flow.py
@@ -1,0 +1,69 @@
+"""Config flow for weatheralerts integration."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import selector
+
+from .sensor import CONF_STATE, CONF_ZONE, CONF_COUNTY  # reuse existing constants
+from .const import DOMAIN  # type: ignore
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WeatheralertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Weather Alerts."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):  # type: ignore[override]
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Basic validation – mimic legacy YAML checks
+            state: str = user_input[CONF_STATE].strip().upper()
+            zone: str = user_input[CONF_ZONE].strip()
+            county: str = user_input.get(CONF_COUNTY, "").strip()
+
+            # Validate input sizes
+            if len(state) != 2:
+                errors[CONF_STATE] = "invalid_state"
+            elif not zone.isdigit() or len(zone) > 3 or len(zone) == 0:
+                errors[CONF_ZONE] = "invalid_zone"
+            elif county and (not county.isdigit() or len(county) > 3):
+                errors[CONF_COUNTY] = "invalid_county"
+            else:
+                # Build unique feed id similar to sensor implementation
+                zone_id = f"{state}Z{zone.zfill(3)}"
+                if county:
+                    county_id = f"{state}C{county.zfill(3)}"
+                    feed_id = f"{zone_id},{county_id}"
+                else:
+                    feed_id = zone_id
+
+                await self.async_set_unique_id(feed_id.replace(",", ""))
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=f"NWS {feed_id}",
+                    data={
+                        CONF_STATE: state,
+                        CONF_ZONE: zone,
+                        CONF_COUNTY: county,
+                    },
+                )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_STATE): str,
+                vol.Required(CONF_ZONE): str,
+                vol.Optional(CONF_COUNTY, default=""): str,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)

--- a/custom_components/weatheralerts/config_flow.py
+++ b/custom_components/weatheralerts/config_flow.py
@@ -61,6 +61,12 @@ class WeatheralertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
 
+
+    async def async_step_import(self, import_data: dict):
+        """Import a config entry from YAML."""
+        # Delegate to async_step_user for validation and entry creation
+        return await self.async_step_user(import_data)
+
     @staticmethod
     def async_get_options_flow(config_entry):  # type: ignore[override]
         """Get the options flow for this handler."""

--- a/custom_components/weatheralerts/config_flow.py
+++ b/custom_components/weatheralerts/config_flow.py
@@ -3,108 +3,602 @@ from __future__ import annotations
 
 import logging
 import voluptuous as vol
+import async_timeout
+import re
+import json
 
 from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import translation
 
-from .sensor import CONF_STATE, CONF_ZONE, CONF_COUNTY
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    CONF_ZONE,
+    CONF_COUNTY,
+    CONF_ZONE_NAME,
+    CONF_NAME,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_ENTITY_NAME,
+    CONF_MARINE_ZONES,
+    CONF_UPDATE_INTERVAL,
+    CONF_API_TIMEOUT,
+    ALERTS_API,
+    POINTS_API,
+    ZONE_API,
+    COUNTY_API,
+    HEADERS,
+    NWS_CODE_REGEX,
+    MARINE_API,
+    CONF_EVENT_ICONS,
+    CONF_DEFAULT_ICON,
+    DEFAULT_EVENT_ICONS,
+    DEFAULT_EVENT_ICON,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_API_TIMEOUT,
+    MIN_UPDATE_INTERVAL,
+    MAX_UPDATE_INTERVAL,
+    MIN_API_TIMEOUT,
+    MAX_API_TIMEOUT,
+    TIMEOUT_BUFFER,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _clean_for_entity_id(text: str) -> str:
+    if not text:
+        return ""
+    return re.sub(r"[^a-z0-9_]", "", re.sub(r"[-\s,]+", "_", text.lower())).strip("_")
+
+async def _get_friendly_error(hass, key):
+    """Return the user-friendly error message for the given key using en.json translation."""
+    # Fetch English translations for your integration
+    translations = await translation.async_get_translations(
+        hass, "en", f"component.{DOMAIN}"
+    )
+    # Path for config flow errors in translations is: config.error.<key>
+    error_path = f"config.error.{key}"
+    return translations.get(error_path, key)
+
+async def _get_zone_name(session, zone):
+    """Fetch the human-readable name of a public-zone code (or “” on failure)."""
+    try:
+        async with async_timeout.timeout(20):
+            resp = await session.get(ZONE_API.format(zone), headers=HEADERS)
+            if resp.status == 200:
+                return (await resp.json()).get("properties", {}).get("name", "")
+    except Exception as ex:
+        _LOGGER.debug("Failed to fetch zone name: %s", ex)
+    return ""
+
+async def _validate_zone_api(hass, zone, county, marine_zones, errors):
+    session = async_get_clientsession(hass)
+    try:
+        async with async_timeout.timeout(20):
+            resp = await session.get(ZONE_API.format(zone), headers=HEADERS)
+            if resp.status == 404:
+                marine_resp = await session.get(MARINE_API.format(zone), headers=HEADERS)
+                if marine_resp.status == 404:
+                    errors["zone"] = "invalid_zone"
+                    errors["base"] = f"Invalid zone code: {zone}"
+                    return False
+            elif resp.status != 200:
+                errors["base"] = "api_outage"
+                return False
+    except Exception:
+        errors["base"] = "api_outage"
+        return False
+    if county:
+        try:
+            async with async_timeout.timeout(20):
+                resp = await session.get(COUNTY_API.format(county), headers=HEADERS)
+                if resp.status == 404:
+                    errors["county"] = "invalid_county"
+                    errors["base"] = f"Invalid county code: {county}"
+                    return False
+                elif resp.status != 200:
+                    errors["base"] = "api_outage"
+                    return False
+        except Exception:
+            errors["base"] = "api_outage"
+            return False
+    for m in marine_zones.split(","):
+        m = m.strip()
+        if not m:
+            continue
+        try:
+            async with async_timeout.timeout(20):
+                resp = await session.get(MARINE_API.format(m), headers=HEADERS)
+                if resp.status == 404:
+                    # Try as zone if not found as marine
+                    zone_resp = await session.get(ZONE_API.format(m), headers=HEADERS)
+                    if zone_resp.status == 404:
+                        errors["marine_zones"] = "invalid_marine"
+                        errors["base"] = f"Invalid marine_zones code: {m}"
+                        return False
+                    elif zone_resp.status != 200:
+                        errors["base"] = "api_outage"
+                        return False
+                elif resp.status != 200:
+                    errors["base"] = "api_outage"
+                    return False
+        except Exception:
+            errors["base"] = "api_outage"
+            return False
+    return True
+
 
 class WeatheralertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Weather Alerts."""
 
-    VERSION = 1
+    VERSION = 2
 
-    async def async_step_user(self, user_input: dict | None = None):  # type: ignore[override]
-        """Handle the initial configuration step."""
-        errors: dict[str, str] = {}
+    def __init__(self):
+        self._lat = None
+        self._lon = None
+        self._parsed_zone = None
+        self._parsed_county = None
+        self._zone = None
+        self._county = None
+        self._marine = None
 
-        if user_input is not None:
-            state = user_input[CONF_STATE].strip().upper()
-            zone = user_input[CONF_ZONE].strip()
-            county = user_input.get(CONF_COUNTY, "").strip()
+    async def async_step_user(self, user_input=None):
+        errors = {}
+        zone_home = self.hass.states.get("zone.home")
+        default_lat = str(zone_home.attributes.get("latitude", "")) if zone_home else ""
+        default_lon = str(zone_home.attributes.get("longitude", "")) if zone_home else ""
+        schema = vol.Schema({
+            vol.Optional(CONF_LATITUDE, default=default_lat): str,
+            vol.Optional(CONF_LONGITUDE, default=default_lon): str,
+        })
 
-            # Validate input sizes
-            if len(state) != 2:
-                errors[CONF_STATE] = "invalid_state"
-            elif not zone.isdigit() or len(zone) == 0 or len(zone) > 3:
-                errors[CONF_ZONE] = "invalid_zone"
-            elif county and (not county.isdigit() or len(county) > 3):
-                errors[CONF_COUNTY] = "invalid_county"
+        if user_input:
+            lat = user_input[CONF_LATITUDE].strip()
+            lon = user_input[CONF_LONGITUDE].strip()
+            self._lat, self._lon = lat, lon
+
+            if not lat or not lon:
+                return await self.async_step_zone(None)
+
+            try:
+                float(lat)
+                float(lon)
+            except ValueError:
+                friendly_error = await _get_friendly_error(self.hass, "invalid_latlon")
+                _LOGGER.error(
+                    "Invalid latitude/longitude: lat=%s, lon=%s - Error: %s",
+                    lat, lon, friendly_error
+                )
+                errors["base"] = "invalid_latlon"
             else:
-                zone_id = f"{state}Z{zone.zfill(3)}"
-                if county:
-                    county_id = f"{state}C{county.zfill(3)}"
-                    feed_id = f"{zone_id},{county_id}"
-                else:
-                    feed_id = zone_id
+                session = async_get_clientsession(self.hass)
+                async with async_timeout.timeout(20):
+                    resp = await session.get(POINTS_API.format(lat, lon), headers=HEADERS)
+                    code = resp.status
+                    # If not 200 and not 404, this is an API outage.
+                    if code != 200 and code != 404:
+                        friendly_error = await _get_friendly_error(self.hass, "api_outage")
+                        _LOGGER.error(
+                            "API outage for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                            lat, lon, code, friendly_error
+                        )
+                        errors["base"] = "api_outage"
+                    # If 404, check JSON
+                    elif code == 404:
+                        try:
+                            data = await resp.json()
+                        except Exception:
+                            data = None
+                        # If no data or no status key in JSON, unknown error
+                        if not data or not isinstance(data, dict) or "status" not in data:
+                            friendly_error = await _get_friendly_error(self.hass, "unknown_error")
+                            _LOGGER.error(
+                                "404 error for lat=%s, lon=%s - HTTP code: 404, error: %s (no valid JSON/status)",
+                                lat, lon, friendly_error
+                            )
+                            errors["base"] = "unknown_error"
+                        else:
+                            # Continue with rest of JSON logic
+                            status = data.get("status")
+                            err_type = data.get("type", "")
+                            if status == 404 and "InvalidPoint" in err_type:
+                                friendly_error = await _get_friendly_error(self.hass, "invalid_point")
+                                _LOGGER.error(
+                                    "InvalidPoint error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, friendly_error
+                                )
+                                errors["base"] = "invalid_point"
+                            elif status is not None and status == 404 and "InvalidPoint" not in err_type:
+                                title = data.get("title", "Unknown Error")
+                                msg = f"{status} - {title} (Out-of-bounds?)"
+                                _LOGGER.error(
+                                    "API error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, msg
+                                )
+                                errors["base"] = msg
+                            elif status is not None and status != 404:
+                                title = data.get("title", "Unknown Error")
+                                msg = f"{status} - {title}"
+                                _LOGGER.error(
+                                    "API error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, msg
+                                )
+                                errors["base"] = msg
+                            else:
+                                props = data.get("properties", {})
+                                self._parsed_zone = props.get("forecastZone", "").split("/")[-1] or ""
+                                self._parsed_county = props.get("county", "").split("/")[-1] or ""
+                                return await self.async_step_zone(None)
+                    # If 200, normal processing
+                    else:
+                        data = await resp.json()
+                        if isinstance(data, dict):
+                            status = data.get("status")
+                            err_type = data.get("type", "")
+                            if status == 404 and "InvalidPoint" in err_type:
+                                friendly_error = await _get_friendly_error(self.hass, "invalid_point")
+                                _LOGGER.error(
+                                    "InvalidPoint error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, friendly_error
+                                )
+                                errors["base"] = "invalid_point"
+                            elif status is not None and status != 404:
+                                title = data.get("title", "Unknown Error")
+                                msg = f"{status} - {title}"
+                                _LOGGER.error(
+                                    "API error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, msg
+                                )
+                                errors["base"] = msg
+                            elif status is not None and status == 404 and "InvalidPoint" not in err_type:
+                                title = data.get("title", "Unknown Error")
+                                msg = f"{status} - {title}  (Out-of-bounds?)"
+                                _LOGGER.error(
+                                    "API error for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                    lat, lon, code, msg
+                                )
+                                errors["base"] = msg
+                            else:
+                                props = data.get("properties", {})
+                                self._parsed_zone = props.get("forecastZone", "").split("/")[-1] or ""
+                                self._parsed_county = props.get("county", "").split("/")[-1] or ""
+                                return await self.async_step_zone(None)
+                        else:
+                            friendly_error = await _get_friendly_error(self.hass, "unknown_error")
+                            _LOGGER.error(
+                                "Unknown error (non-dict API response) for lat=%s, lon=%s - HTTP code: %s, error: %s",
+                                lat, lon, code, friendly_error
+                            )
+                            errors["base"] = "unknown_error"
 
-                await self.async_set_unique_id(feed_id.replace(",", ""))
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_zone(self, user_input=None):
+        errors = {}
+        suggested_zone = self._parsed_zone or ""
+        suggested_county = self._parsed_county or ""
+        schema = vol.Schema({
+            vol.Required(CONF_ZONE): str,
+            vol.Optional(CONF_COUNTY): str,
+            vol.Optional(CONF_MARINE_ZONES): str,
+        })
+        schema = self.add_suggested_values_to_schema(schema, {
+            CONF_ZONE: suggested_zone,
+            CONF_COUNTY: suggested_county,
+            CONF_MARINE_ZONES: "",
+        })
+
+        if user_input:
+            zone = user_input[CONF_ZONE].strip().upper()
+            county = user_input.get(CONF_COUNTY, "").strip().upper()
+            marine = user_input.get(CONF_MARINE_ZONES, "").strip().upper()
+
+            if not re.match(NWS_CODE_REGEX, zone):
+                errors["zone"] = "invalid_zone"
+                errors["base"] = f"Invalid zone code: {zone}"
+            elif county and not re.match(NWS_CODE_REGEX, county):
+                errors["county"] = "invalid_county"
+                errors["base"] = f"Invalid county code: {county}"
+            elif marine and not all(re.match(NWS_CODE_REGEX, m.strip()) for m in marine.split(",") if m.strip()):
+                errors["marine_zones"] = "invalid_marine"
+                invalid_m = next((m for m in marine.split(",") if not re.match(NWS_CODE_REGEX, m.strip())), "")
+                errors["base"] = f"Invalid zone code: {invalid_m}"
+            else:
+                valid = await _validate_zone_api(self.hass, zone, county, marine, errors)
+                if not valid:
+                    return self.async_show_form(step_id="zone", data_schema=schema, errors=errors)
+
+                # Store for next step
+                self._zone = zone
+                self._county = county
+                self._marine = marine
+
+                return await self.async_step_update_options()
+
+        return self.async_show_form(step_id="zone", data_schema=schema, errors=errors)
+
+    async def async_step_update_options(self, user_input=None):
+        from .const import (
+            CONF_UPDATE_INTERVAL,
+            CONF_API_TIMEOUT,
+            DEFAULT_UPDATE_INTERVAL,
+            DEFAULT_API_TIMEOUT,
+            MIN_UPDATE_INTERVAL,
+            MAX_UPDATE_INTERVAL,
+            MIN_API_TIMEOUT,
+            MAX_API_TIMEOUT,
+            TIMEOUT_BUFFER,
+        )
+
+        errors = {}
+        schema = vol.Schema({
+            vol.Required(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): int,
+            vol.Required(CONF_API_TIMEOUT, default=DEFAULT_API_TIMEOUT): int,
+        })
+
+        if user_input:
+            update = int(user_input[CONF_UPDATE_INTERVAL])
+            timeout = int(user_input[CONF_API_TIMEOUT])
+
+            if update < MIN_UPDATE_INTERVAL or update > MAX_UPDATE_INTERVAL:
+                errors[CONF_UPDATE_INTERVAL] = f"Must be between {MIN_UPDATE_INTERVAL} and {MAX_UPDATE_INTERVAL}"
+            elif timeout < MIN_API_TIMEOUT or timeout > MAX_API_TIMEOUT:
+                errors[CONF_API_TIMEOUT] = f"Must be between {MIN_API_TIMEOUT} and {MAX_API_TIMEOUT}"
+            elif timeout >= update - TIMEOUT_BUFFER:
+                errors[CONF_API_TIMEOUT] = f"Must be at least {TIMEOUT_BUFFER}s less than update interval"
+            else:
+                # Construct entity
+                parts = [self._zone]
+                if self._county:
+                    parts.append(self._county)
+                parts += [m.strip() for m in self._marine.split(",") if m.strip()]
+                feed_id = ",".join(parts)
+
+                session = async_get_clientsession(self.hass)
+                zone_name = await _get_zone_name(session, self._zone)
+                if zone_name and len(zone_name) > 40:
+                    zone_name = "NWS"
+                clean_name = _clean_for_entity_id(zone_name or self._zone)
+                clean_id = _clean_for_entity_id(feed_id)
+                entity_name = f"weatheralerts_{clean_name}_{clean_id}"
+                friendly_name = f"{zone_name} ({feed_id})" if zone_name else f"NWS ({feed_id})"
+
+                await self.async_set_unique_id(f"{DOMAIN}_{clean_id}")
                 self._abort_if_unique_id_configured()
 
-                return self.async_create_entry(
-                    title=f"NWS {feed_id}",
-                    data={
-                        CONF_STATE: state,
-                        CONF_ZONE: zone,
-                        CONF_COUNTY: county,
-                    },
-                )
+                data = {
+                    CONF_ZONE: self._zone,
+                    CONF_ZONE_NAME: zone_name,
+                    CONF_NAME: friendly_name,
+                    CONF_ENTITY_NAME: entity_name,
+                    CONF_UPDATE_INTERVAL: update,
+                    CONF_API_TIMEOUT: timeout,
+                }
+                if self._county:
+                    data[CONF_COUNTY] = self._county
+                if self._lat and self._lon:
+                    data[CONF_LATITUDE] = self._lat
+                    data[CONF_LONGITUDE] = self._lon
+                if self._marine:
+                    data[CONF_MARINE_ZONES] = self._marine
 
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_STATE): str,
-                vol.Required(CONF_ZONE): str,
-                vol.Optional(CONF_COUNTY, default=""): str,
-            }
-        )
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+                return self.async_create_entry(title=friendly_name, data=data)
 
+        return self.async_show_form(step_id="update_options", data_schema=schema, errors=errors)
 
-    async def async_step_import(self, import_data: dict):
-        """Import a config entry from YAML."""
-        # Delegate to async_step_user for validation and entry creation
-        return await self.async_step_user(import_data)
+    async def async_step_import(self, import_data):
+        """Silent import of YAML — no user input required."""
+        state = import_data.get("state", "")
+        raw_zone = import_data.get("zone", "")
+        raw_county = import_data.get("county", "")
+
+        # Normalize codes
+        if state and raw_zone and len(str(raw_zone)) <= 3:
+            zone = f"{state.upper()}Z{str(raw_zone).zfill(3)}"
+        else:
+            zone = raw_zone.upper()
+        if state and raw_county and len(str(raw_county)) <= 3:
+            county = f"{state.upper()}C{str(raw_county).zfill(3)}"
+        else:
+            county = raw_county.upper()
+
+        # No marine zones in YAML
+        marine = ""
+
+        # Fetch zone_name (=40 chars, else fallback to 'NWS')
+        session = async_get_clientsession(self.hass)
+        zone_name = await _get_zone_name(session, zone)
+        if zone_name and len(zone_name) > 40:
+            zone_name = "NWS"
+
+        # Build feed_id, entity & friendly names
+        feed_parts = [zone] + ([county] if county else []) + []
+        feed_id = ",".join(feed_parts)
+        clean_name = _clean_for_entity_id(zone_name or zone)
+        clean_id = _clean_for_entity_id(feed_id)
+        entity_name = f"weatheralerts_{clean_name}_{clean_id}"
+        friendly_name = f"{zone_name} ({feed_id})" if zone_name else f"NWS ({feed_id})"
+
+        # Ensure uniqueness & avoid dupes
+        await self.async_set_unique_id(f"{DOMAIN}_{clean_id}")
+        self._abort_if_unique_id_configured()
+
+        data = {
+            CONF_ZONE: zone,
+            CONF_COUNTY: county,
+            CONF_ZONE_NAME: zone_name,
+            CONF_NAME: friendly_name,
+            CONF_ENTITY_NAME: entity_name,
+        }
+        # No latitude/longitude from YAML import
+        # No marine zones
+
+        return self.async_create_entry(title=friendly_name, data=data)
 
     @staticmethod
-    def async_get_options_flow(config_entry):  # type: ignore[override]
-        """Get the options flow for this handler."""
-        return WeatheralertsOptionsFlow(config_entry)
+    @callback
+    def async_get_options_flow(entry):
+        return WeatheralertsOptionsFlow(entry)
+
 
 class WeatheralertsOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for Weather Alerts."""
 
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
+    def __init__(self, entry):
+        self._entry = entry
+        self.updated_options = dict(entry.options)
+        for key in [CONF_ZONE, CONF_COUNTY, CONF_MARINE_ZONES, CONF_NAME, CONF_ENTITY_NAME, CONF_ZONE_NAME]:
+            if key not in self.updated_options and key in entry.data:
+                self.updated_options[key] = entry.data[key]
 
-    async def async_step_init(self, user_input: dict | None = None):  # type: ignore[override]
-        """Manage the options."""
-        errors: dict[str, str] = {}
+    async def async_step_init(self, user_input=None):
+        errors = {}
+        schema = vol.Schema({
+            vol.Required(CONF_ZONE): str,
+            vol.Optional(CONF_COUNTY): str,
+            vol.Optional(CONF_MARINE_ZONES): str,
+        })
+        data_schema = self.add_suggested_values_to_schema(schema, self.updated_options)
+
         if user_input is not None:
-            state = user_input[CONF_STATE].strip().upper()
-            zone = user_input[CONF_ZONE].strip()
-            county = user_input.get(CONF_COUNTY, "").strip()
+            zone = user_input[CONF_ZONE].strip().upper()
+            county = user_input.get(CONF_COUNTY, "").strip().upper()
+            marine = user_input.get(CONF_MARINE_ZONES, "").strip().upper()
+            
+            # VALIDATION using config flow logic
+            valid = await _validate_zone_api(self.hass, zone, county, marine, errors)
+            if not valid:
+                # Show the form again with error(s)
+                return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors)
 
-            # Validate input sizes
-            if len(state) != 2:
-                errors[CONF_STATE] = "invalid_state"
-            elif not zone.isdigit() or len(zone) == 0 or len(zone) > 3:
-                errors[CONF_ZONE] = "invalid_zone"
-            elif county and (not county.isdigit() or len(county) > 3):
-                errors[CONF_COUNTY] = "invalid_county"
-            else:
-                return self.async_create_entry(title="", data={
-                    CONF_STATE: state,
-                    CONF_ZONE: zone,
-                    CONF_COUNTY: county,
-                })
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_STATE, default=self.config_entry.options.get(CONF_STATE, self.config_entry.data[CONF_STATE])): str,
-                vol.Required(CONF_ZONE, default=self.config_entry.options.get(CONF_ZONE, self.config_entry.data[CONF_ZONE])): str,
-                vol.Required(CONF_COUNTY, default=self.config_entry.options.get(CONF_COUNTY, self.config_entry.data.get(CONF_COUNTY, ""))): str,
-            }
-        )
+            parts = [zone] + ([county] if county else []) + [m.strip() for m in marine.split(",") if m.strip()]
+            feed_id = ",".join(parts)
+            session = async_get_clientsession(self.hass)
+            session = async_get_clientsession(self.hass)
+            zone_name = await _get_zone_name(session, zone)
+            if zone_name and len(zone_name) > 40:
+                zone_name = "NWS"
+            friendly_name = f"{zone_name} ({feed_id})" if zone_name else f"NWS ({feed_id})"
+            entity_name = f"weatheralerts_{_clean_for_entity_id(zone_name or zone)}_{_clean_for_entity_id(feed_id)}"
+
+            self.updated_options[CONF_ZONE] = zone
+            self.updated_options[CONF_COUNTY] = county
+            self.updated_options[CONF_MARINE_ZONES] = marine
+            self.updated_options[CONF_ZONE_NAME] = zone_name
+            self.updated_options[CONF_NAME] = friendly_name
+            self.updated_options[CONF_ENTITY_NAME] = entity_name
+
+            self.hass.config_entries.async_update_entry(self._entry, title=friendly_name)
+            return await self.async_step_update_options()
+
         return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors)
+
+    async def async_step_update_options(self, user_input=None):
+        errors = {}
+        update = self.updated_options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        timeout = self.updated_options.get(CONF_API_TIMEOUT, DEFAULT_API_TIMEOUT)
+
+        schema = vol.Schema({
+            vol.Required(CONF_UPDATE_INTERVAL, default=update): int,
+            vol.Required(CONF_API_TIMEOUT, default=timeout): int,
+        })
+
+        if user_input:
+            update = int(user_input[CONF_UPDATE_INTERVAL])
+            timeout = int(user_input[CONF_API_TIMEOUT])
+
+            if update < MIN_UPDATE_INTERVAL or update > MAX_UPDATE_INTERVAL:
+                errors[CONF_UPDATE_INTERVAL] = f"Must be between {MIN_UPDATE_INTERVAL} and {MAX_UPDATE_INTERVAL}"
+            elif timeout < MIN_API_TIMEOUT or timeout > MAX_API_TIMEOUT:
+                errors[CONF_API_TIMEOUT] = f"Must be between {MIN_API_TIMEOUT} and {MAX_API_TIMEOUT}"
+            elif timeout >= update - TIMEOUT_BUFFER:
+                errors[CONF_API_TIMEOUT] = f"Must be at least {TIMEOUT_BUFFER}s less than update interval"
+            else:
+                self.updated_options[CONF_UPDATE_INTERVAL] = update
+                self.updated_options[CONF_API_TIMEOUT] = timeout
+                return await self.async_step_icon_config()
+
+        return self.async_show_form(step_id="update_options", data_schema=schema, errors=errors)
+
+    async def async_step_icon_config(self, user_input=None):
+        """Icon configuration step for options flow."""
+        errors = {}
+
+        import json
+
+        # Load existing icons from updated_options or entry options
+        raw = self.updated_options.get(
+            CONF_EVENT_ICONS,
+            self._entry.options.get(CONF_EVENT_ICONS, {})
+        )
+        icon_data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+
+        # Default icon (existing or built-in)
+        default_icon = self.updated_options.get(
+            CONF_DEFAULT_ICON,
+            self._entry.options.get(CONF_DEFAULT_ICON, DEFAULT_EVENT_ICON)
+        )
+
+        # Base mapping + overrides
+        icon_map = {**DEFAULT_EVENT_ICONS, **icon_data}
+
+        suggested_values = dict(icon_map)
+        suggested_values[CONF_DEFAULT_ICON] = default_icon
+
+        base_schema = {
+            vol.Optional(CONF_DEFAULT_ICON, default="", description={"suggested_value": default_icon}): str,
+            vol.Optional("new_event_type", default=""): str,
+            vol.Optional("new_icon_def", default=""): str,
+        }
+        for event in sorted(icon_map):
+            base_schema[vol.Optional(event, default="")] = str
+
+        schema = vol.Schema(base_schema)
+        data_schema = self.add_suggested_values_to_schema(schema, suggested_values)
+
+        if user_input is not None:
+            new_opts = dict(self.updated_options)
+
+            # Handle Default Icon (now always present in user_input)
+            iv = user_input.get(CONF_DEFAULT_ICON, None)
+            if iv is None:
+                # Defensive: key missing from form, treat as reset to default
+                new_opts.pop(CONF_DEFAULT_ICON, None)
+            else:
+                iv = iv.strip()
+                if not iv or iv == DEFAULT_EVENT_ICON:
+                    new_opts.pop(CONF_DEFAULT_ICON, None)
+                else:
+                    new_opts[CONF_DEFAULT_ICON] = iv
+    
+            # New event mapping
+            new_event = user_input.get("new_event_type", "").strip()
+            new_icon = user_input.get("new_icon_def", "").strip()
+            if new_event and new_icon:
+                icon_data[new_event] = new_icon
+
+            # Existing icons—including cleared ones
+            for event in sorted(icon_map):
+                if event in user_input:
+                    val = user_input[event].strip()
+                    if val:
+                        icon_data[event] = val
+                    else:
+                        icon_data.pop(event, None)
+
+            # Persist icon overrides or remove entirely if empty
+            if icon_data:
+                new_opts[CONF_EVENT_ICONS] = icon_data
+            else:
+                new_opts.pop(CONF_EVENT_ICONS, None)
+
+            self.updated_options = new_opts
+            return self.async_create_entry(data=new_opts)
+
+        return self.async_show_form(
+            step_id="icon_config",
+            data_schema=data_schema,
+            errors=errors,
+        )

--- a/custom_components/weatheralerts/config_flow.py
+++ b/custom_components/weatheralerts/config_flow.py
@@ -98,7 +98,7 @@ class WeatheralertsOptionsFlow(config_entries.OptionsFlow):
             {
                 vol.Required(CONF_STATE, default=self.config_entry.options.get(CONF_STATE, self.config_entry.data[CONF_STATE])): str,
                 vol.Required(CONF_ZONE, default=self.config_entry.options.get(CONF_ZONE, self.config_entry.data[CONF_ZONE])): str,
-                vol.Optional(CONF_COUNTY, default=self.config_entry.options.get(CONF_COUNTY, self.config_entry.data.get(CONF_COUNTY, ""))): str,
+                vol.Required(CONF_COUNTY, default=self.config_entry.options.get(CONF_COUNTY, self.config_entry.data.get(CONF_COUNTY, ""))): str,
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors)

--- a/custom_components/weatheralerts/const.py
+++ b/custom_components/weatheralerts/const.py
@@ -1,0 +1,3 @@
+"""Constants for weatheralerts integration."""
+
+DOMAIN = "weatheralerts"

--- a/custom_components/weatheralerts/const.py
+++ b/custom_components/weatheralerts/const.py
@@ -1,3 +1,180 @@
 """Constants for weatheralerts integration."""
 
 DOMAIN = "weatheralerts"
+VERSION = "2025.7.0"
+
+# Configuration keys
+CONF_ZONE = "zone"
+CONF_COUNTY = "county"
+CONF_ZONE_NAME = "zone_name"
+CONF_NAME = "name"
+CONF_LATITUDE = "latitude"
+CONF_LONGITUDE = "longitude"
+CONF_ENTITY_NAME = "entity_name"
+CONF_MARINE_ZONES = "marine_zones"
+CONF_UPDATE_INTERVAL = "update_interval"
+CONF_API_TIMEOUT = "api_timeout"
+
+# Icon config keys for options flow
+CONF_EVENT_ICONS = "event_icons"
+CONF_DEFAULT_ICON = "default_icon"
+
+# API endpoints
+ALERTS_API = "https://api.weather.gov/alerts/active?zone={}"
+ZONE_API = "https://api.weather.gov/zones/public/{}"
+COUNTY_API = "https://api.weather.gov/zones/county/{}"
+POINTS_API = "https://api.weather.gov/points/{},{}"
+MARINE_API = "https://api.weather.gov/zones/marine/{}"
+
+# HTTP headers for API requests
+HEADERS = {
+    "accept": "application/json",
+    "user-agent": f"HomeAssistant_weatheralerts/{VERSION}",
+}
+
+# Valid NWS code regex for all alert zone/county/marine codes (e.g. WIZ013, WIC087, LMZ043)
+NWS_CODE_REGEX = r"^(A[KLMNRSZ]|C[AOT]|D[CE]|F[LM]|G[AMU]|I[ADLN]|K[SY]|L[ACEHMOS]|M[ADEHINOPST]|N[CDEHJMVY]|O[HKR]|P[AHKMRSWZ]|S[CDL]|T[NX]|UT|V[AIT]|W[AIVY]|[HR]I)[CZ]\d{3}$"
+
+# Defaults for update_interval and timeout options (in seconds)
+DEFAULT_UPDATE_INTERVAL = 90
+DEFAULT_API_TIMEOUT = 20
+MIN_UPDATE_INTERVAL = 30
+MAX_UPDATE_INTERVAL = 600
+MIN_API_TIMEOUT = 10
+MAX_API_TIMEOUT = 60
+TIMEOUT_BUFFER = 5  # Minimum difference between update interval and timeout
+
+# Default icon for unknown/other event types
+DEFAULT_EVENT_ICON = "hass:alert-rhombus"
+
+# Default mapping of alert "event" to icon (case preserved, but match case-insensitively)
+DEFAULT_EVENT_ICONS = {
+    '911 Telephone Outage Emergency': 'hass:phone-alert',
+    'Administrative Message': 'hass:message-text',
+    'Air Quality Alert': 'hass:blur',
+    'Air Stagnation Advisory': 'hass:blur',
+    'Arroyo And Small Stream Flood Advisory': 'hass:water-alert',
+    'Ashfall Advisory': 'hass:cloud-alert',
+    'Ashfall Warning': 'hass:cloud-alert',
+    'Avalanche Advisory': 'hass:alert',
+    'Avalanche Warning': 'hass:alert',
+    'Avalanche Watch': 'hass:alert',
+    'Beach Hazards Statement': 'hass:beach',
+    'Blizzard Warning': 'hass:snowflake-alert',
+    'Blizzard Watch': 'hass:snowflake-alert',
+    'Blowing Dust Advisory': 'hass:blur',
+    'Blowing Dust Warning': 'hass:blur',
+    'Brisk Wind Advisory': 'hass:weather-windy',
+    'Child Abduction Emergency': 'hass:human-male-child',
+    'Civil Danger Warning': 'hass:image-filter-hdr',
+    'Civil Emergency Message': 'hass:image-filter-hdr',
+    'Coastal Flood Advisory': 'hass:waves',
+    'Coastal Flood Statement': 'hass:waves',
+    'Coastal Flood Warning': 'hass:waves',
+    'Coastal Flood Watch': 'hass:waves',
+    'Dense Fog Advisory': 'hass:weather-fog',
+    'Dense Smoke Advisory': 'hass:smoke',
+    'Dust Advisory': 'hass:blur',
+    'Dust Storm Warning': 'hass:blur',
+    'Earthquake Warning': 'hass:alert',
+    'Evacuation - Immediate': 'hass:exit-run',
+    'Excessive Heat Warning': 'hass:thermometer-plus',
+    'Excessive Heat Watch': 'hass:thermometer-plus',
+    'Extreme Cold Warning': 'hass:thermometer-minus',
+    'Extreme Cold Watch': 'hass:thermometer-minus',
+    'Extreme Fire Danger': 'hass:fire-alert',
+    'Extreme Wind Warning': 'hass:weather-windy',
+    'Fire Warning': 'hass:fire-alert',
+    'Fire Weather Watch': 'hass:fire-alert',
+    'Flash Flood Statement': 'hass:water-alert',
+    'Flash Flood Warning': 'hass:water-alert',
+    'Flash Flood Watch': 'hass:water-alert',
+    'Flood Advisory': 'hass:water-alert',
+    'Flood Statement': 'hass:water-alert',
+    'Flood Warning': 'hass:water-alert',
+    'Flood Watch': 'hass:water-alert',
+    'Freeze Warning': 'hass:thermometer-minus',
+    'Freeze Watch': 'hass:thermometer-minus',
+    'Freezing Fog Advisory': 'hass:snowflake-alert',
+    'Freezing Rain Advisory': 'hass:snowflake-alert',
+    'Freezing Spray Advisory': 'hass:snowflake-alert',
+    'Frost Advisory': 'hass:snowflake-alert',
+    'Gale Warning': 'hass:weather-windy',
+    'Gale Watch': 'hass:weather-windy',
+    'Hard Freeze Warning': 'hass:thermometer-minus',
+    'Hard Freeze Watch': 'hass:thermometer-minus',
+    'Hazardous Materials Warning': 'hass:radioactive',
+    'Hazardous Seas Warning': 'hass:sail-boat',
+    'Hazardous Seas Watch': 'hass:sail-boat',
+    'Hazardous Weather Outlook': 'hass:message-alert',
+    'Heat Advisory': 'hass:thermometer-plus',
+    'Heavy Freezing Spray Warning': 'hass:snowflake-alert',
+    'Heavy Freezing Spray Watch': 'hass:snowflake-alert',
+    'High Surf Advisory': 'hass:surfing',
+    'High Surf Warning': 'hass:surfing',
+    'High Wind Warning': 'hass:weather-windy',
+    'High Wind Watch': 'hass:weather-windy',
+    'Hurricane Force Wind Warning': 'hass:weather-hurricane',
+    'Hurricane Force Wind Watch': 'hass:weather-hurricane',
+    'Hurricane Local Statement': 'hass:weather-hurricane',
+    'Hurricane Warning': 'hass:weather-hurricane',
+    'Hurricane Watch': 'hass:weather-hurricane',
+    'Hydrologic Advisory': 'hass:message-text',
+    'Hydrologic Outlook': 'hass:message-text',
+    'Ice Storm Warning': 'hass:snowflake-alert',
+    'Lake Effect Snow Advisory': 'hass:snowflake-alert',
+    'Lake Effect Snow Warning': 'hass:snowflake-alert',
+    'Lake Effect Snow Watch': 'hass:snowflake-alert',
+    'Lake Wind Advisory': 'hass:weather-windy',
+    'Lakeshore Flood Advisory': 'hass:waves-arrow-up',
+    'Lakeshore Flood Statement': 'hass:waves-arrow-up',
+    'Lakeshore Flood Warning': 'hass:waves-arrow-up',
+    'Lakeshore Flood Watch': 'hass:waves-arrow-up',
+    'Law Enforcement Warning': 'hass:car-emergency',
+    'Local Area Emergency': 'hass:alert',
+    'Low Water Advisory': 'hass:wave',
+    'Marine Weather Statement': 'hass:sail-boat',
+    'Nuclear Power Plant Warning': 'hass:radioactive',
+    'Radiological Hazard Warning': 'hass:biohazard',
+    'Red Flag Warning': 'hass:fire-alert',
+    'Rip Current Statement': 'hass:surfing',
+    'Severe Thunderstorm Warning': 'hass:weather-lightning',
+    'Severe Thunderstorm Watch': 'hass:weather-lightning',
+    'Severe Weather Statement': 'hass:message-text',
+    'Shelter In Place Warning': 'hass:account-box',
+    'Short Term Forecast': 'hass:message-text',
+    'Small Craft Advisory': 'hass:sail-boat',
+    'Small Craft Advisory For Hazardous Seas': 'hass:sail-boat',
+    'Small Craft Advisory For Rough Bar': 'hass:sail-boat',
+    'Small Craft Advisory For Winds': 'hass:sail-boat',
+    'Small Stream Flood Advisory': 'hass:water-alert',
+    'Snow Squall Warning': 'hass:snowflake-alert',
+    'Special Marine Warning': 'hass:sail-boat',
+    'Special Weather Statement': 'hass:message-alert',
+    'Storm Surge Warning': 'hass:waves-arrow-up',
+    'Storm Surge Watch': 'hass:waves-arrow-up',
+    'Storm Warning': 'hass:weather-lightning',
+    'Storm Watch': 'hass:weather-lightning',
+    'Test': 'hass:message-text',
+    'Tornado Warning': 'hass:weather-tornado',
+    'Tornado Watch': 'hass:weather-tornado',
+    'Tropical Depression Local Statement': 'hass:weather-hurricane',
+    'Tropical Storm Local Statement': 'hass:weather-hurricane',
+    'Tropical Storm Warning': 'hass:weather-hurricane',
+    'Tropical Storm Watch': 'hass:weather-hurricane',
+    'Tsunami Advisory': 'hass:waves-arrow-up',
+    'Tsunami Warning': 'hass:waves-arrow-up',
+    'Tsunami Watch': 'hass:waves-arrow-up',
+    'Typhoon Local Statement': 'hass:weather-hurricane',
+    'Typhoon Warning': 'hass:weather-hurricane',
+    'Typhoon Watch': 'hass:weather-hurricane',
+    'Urban And Small Stream Flood Advisory': 'hass:home-flood',
+    'Volcano Warning': 'hass:image-filter-hdr',
+    'Wind Advisory': 'hass:weather-windy',
+    'Wind Chill Advisory': 'hass:thermometer-minus',
+    'Wind Chill Warning': 'hass:thermometer-minus',
+    'Wind Chill Watch': 'hass:thermometer-minus',
+    'Winter Storm Warning': 'hass:snowflake-alert',
+    'Winter Storm Watch': 'hass:snowflake-alert',
+    'Winter Weather Advisory': 'hass:snowflake-alert',
+}

--- a/custom_components/weatheralerts/manifest.json
+++ b/custom_components/weatheralerts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "weatheralerts",
-  "name": "Weatheralerts",
+  "name": "Weather Alerts",
   "documentation": "https://github.com/custom-components/weatheralerts",
   "config_flow": true,
   "dependencies": [],
@@ -9,5 +9,6 @@
     "@jlverhagen"
   ],
   "requirements": [],
-  "version": "2025.6.0"
+  "version": "2025.8.0",
+  "translations": [ "en" ]
 }

--- a/custom_components/weatheralerts/manifest.json
+++ b/custom_components/weatheralerts/manifest.json
@@ -2,11 +2,12 @@
   "domain": "weatheralerts",
   "name": "Weatheralerts",
   "documentation": "https://github.com/custom-components/weatheralerts",
+  "config_flow": true,
   "dependencies": [],
   "codeowners": [
     "@ludeeus",
     "@jlverhagen"
   ],
   "requirements": [],
-  "version": "0.1.5"
+  "version": "2025.6.0"
 }

--- a/custom_components/weatheralerts/sensor.py
+++ b/custom_components/weatheralerts/sensor.py
@@ -15,6 +15,8 @@ from homeassistant.const import __version__
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from .const import DOMAIN
+
 
 CONF_STATE = "state"
 CONF_ZONE = "zone"
@@ -121,8 +123,15 @@ async def _async_setup(hass, config, add_entities):
 async def async_setup_platform(
     hass, config, add_entities, discovery_info=None
 ):  # pylint: disable=missing-docstring, unused-argument
-    """Legacy YAML setup."""
-    return await _async_setup(hass, config, add_entities)
+    """Deprecated YAML setup.
+
+    YAML configuration for weatheralerts is deprecated and no longer supported; please configure via the Home Assistant UI.
+    """
+    _LOGGER.warning(
+        "YAML configuration for weatheralerts is deprecated and no longer supported; please configure via the Home Assistant UI."
+    )
+    return True
+
 
 
 async def async_setup_entry(hass, entry, add_entities):

--- a/custom_components/weatheralerts/sensor.py
+++ b/custom_components/weatheralerts/sensor.py
@@ -1,284 +1,473 @@
 """
 An integration which allows you to get weather alerts from weather.gov.
 For more details about this integration, please refer to the documentation at
-
 https://github.com/custom-components/weatheralerts
 """
-import sys
 import logging
 import async_timeout
-import voluptuous as vol
+import re
+from datetime import timedelta
 
-from homeassistant.exceptions import PlatformNotReady
-from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.const import __version__
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
-from .const import DOMAIN
+from homeassistant.components.sensor import SensorEntity, RestoreEntity
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    CoordinatorEntity,
+    UpdateFailed,
+)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
 
-
-CONF_STATE = "state"
-CONF_ZONE = "zone"
-CONF_COUNTY = "county"
+from .const import (
+    DOMAIN,
+    ALERTS_API,
+    HEADERS,
+    CONF_ZONE,
+    CONF_COUNTY,
+    CONF_ZONE_NAME,
+    CONF_NAME,
+    CONF_ENTITY_NAME,
+    CONF_MARINE_ZONES,
+    CONF_EVENT_ICONS,
+    CONF_DEFAULT_ICON,
+    DEFAULT_EVENT_ICONS,
+    DEFAULT_EVENT_ICON,
+    CONF_UPDATE_INTERVAL,
+    CONF_API_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_API_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_STATE): cv.string,
-        vol.Required(CONF_ZONE): cv.string,
-        vol.Optional(CONF_COUNTY, default=''): cv.string,
-    }
-)
+def _clean_for_entity_id(text):
+    return re.sub(r'[^a-z0-9_]', '', re.sub(r'[-\s,]+', '_', text.lower())).strip('_')
 
-URL = "https://api.weather.gov/alerts/active?zone={}"
-URL_ID_CHECK = "https://alerts.weather.gov/cap/wwaatmget.php?x={}&y=0"
-ID_CHECK_ERRORS = ["? invalid county", "? invalid zone"]
+def _get_icon_for_event(event, entry_options=None):
+    event_icons = None
+    default_icon = None
+    if entry_options:
+        event_icons = entry_options.get(CONF_EVENT_ICONS)
+        default_icon = entry_options.get(CONF_DEFAULT_ICON)
+        if isinstance(event_icons, str):
+            import json
+            try:
+                event_icons = json.loads(event_icons)
+            except Exception:
+                event_icons = None
+    if not event_icons or not isinstance(event_icons, dict):
+        event_icons = DEFAULT_EVENT_ICONS
+    if not default_icon or not isinstance(default_icon, str):
+        default_icon = DEFAULT_EVENT_ICON
+    lower_map = {k.lower(): v for k, v in event_icons.items()}
+    icon = lower_map.get(str(event or "").strip().lower())
+    return icon if icon else default_icon
 
-HEADERS = {
-    "accept": "application/ld+json",
-    "user-agent": f"HomeAssistant/{__version__}",
-}
-
-
-async def _async_setup(hass, config, add_entities):
-    """Shared setup logic for YAML platform and config entry."""
-    state = config[CONF_STATE].upper()
-    zone_config = config[CONF_ZONE]
-    county_config = config[CONF_COUNTY]
-
-    zone = zone_config
-    county = county_config
-
-    if len(state) != 2:
-        _LOGGER.error("Configured state '%s' is not valid", state)
-        return False
-
-    if len(zone) == 1:
-        zone = f"00{zone}"
-    if len(zone) == 2:
-        zone = f"0{zone}"
-    if len(zone) == 3:
-        zoneid = f"{state}Z{zone}"
-    else:
-        _LOGGER.error("Configured zone ID '%s' is not valid", zone_config)
-        return False
-
-    if len(county) == 1:
-        county = f"00{county}"
-    if len(county) == 2:
-        county = f"0{county}"
-    if len(county) == 3:
-        countyid = f"{state}C{county}"
-    elif county != "":
-        _LOGGER.error("Configured county ID '%s' is not valid", county_config)
-        return False
-
-    if len(county) == 3:
-        feedid = f"{zoneid},{countyid}"
-    else:
-        feedid = zoneid
-
-    session = async_create_clientsession(hass)
-
-    try:
-        async with async_timeout.timeout(20):
-            zone_check_response = await session.get(URL_ID_CHECK.format(zoneid))
-            zone_data = await zone_check_response.text()
-
-            if any(id_error in zone_data for id_error in ID_CHECK_ERRORS):
-                _LOGGER.error("Compiled zone ID '%s' is not valid", zoneid)
+def _compute_active_alert_stats(alerts):
+    now_ts = dt_util.as_timestamp(dt_util.now())
+    def is_active(alert):
+        ends_str = alert.get("expires")
+        if not ends_str or ends_str == "null":
+            return False
+        try:
+            ends_ts = dt_util.as_timestamp(ends_str)
+            if not ends_ts:
                 return False
+            return (ends_ts - now_ts) > 0
+        except Exception:
+            _LOGGER.debug(f"weatheralerts: Could not parse 'expires' for active_alert_stats: {ends_str}")
+            return False
 
-        if len(county) == 3:
-            async with async_timeout.timeout(20):
-                county_check_response = await session.get(URL_ID_CHECK.format(countyid))
-                county_data = await county_check_response.text()
-
-                if any(id_error in county_data for id_error in ID_CHECK_ERRORS):
-                    _LOGGER.error("Compiled county ID '%s' is not valid", countyid)
-                    return False
-
-        async with async_timeout.timeout(20):
-            response = await session.get(URL.format(zoneid))
-            data = await response.json()
-
-            if data.get("status") == 404:
-                _LOGGER.error("Compiled zone ID '%s' is not valid", zoneid)
-                return False
-
-            name = data["title"].split("advisories for ")[1].split(" (")[0]
-
-    except Exception as exception:  # pylint: disable=broad-except
-        _LOGGER.warning("[%s] %s", sys.exc_info()[0].__name__, exception)
-        raise PlatformNotReady from exception
-
-    add_entities([WeatherAlertsSensor(name, state, feedid, session)], True)
-    _LOGGER.debug("Added sensor '%s' for feedid '%s'", name, feedid)
-
-    return True
-
-
-async def async_setup_platform(
-    hass, config, add_entities, discovery_info=None
-):  # pylint: disable=missing-docstring, unused-argument
-    """Deprecated YAML setup.
-
-    YAML configuration for weatheralerts is deprecated and no longer supported; please configure via the Home Assistant UI.
-    """
-    _LOGGER.warning(
-        "YAML configuration for weatheralerts is deprecated and no longer supported; please configure via the Home Assistant UI."
-    )
-    return True
-
-
-
-async def async_setup_entry(hass, entry, add_entities):
-    """Set up sensors from config entry."""
-    # Load configuration from entry options if available, else use initial data
-    config = {
-        CONF_STATE: entry.options.get(CONF_STATE, entry.data[CONF_STATE]),
-        CONF_ZONE: entry.options.get(CONF_ZONE, entry.data[CONF_ZONE]),
-        CONF_COUNTY: entry.options.get(CONF_COUNTY, entry.data.get(CONF_COUNTY, "")),
+    categories = {
+        "active_warning": "warning",
+        "active_watch": "watch",
+        "active_advisory": "advisory",
+        "active_statement": "statement",
+        "active_outlook": "outlook",
+        "active_alert": "alert",
+        "active_message": "message",
+        "active_important": "important",
+        "active_test": "test",
+        "active_outage": "outage",
+        "active_emergency": "emergency",
+        "active_immediate": "immediate",
+        "active_forecast": "forecast",
     }
-    return await _async_setup(hass, config, add_entities)
 
-class WeatherAlertsSensor(Entity):  # pylint: disable=missing-docstring
-    def __init__(self, name, zone_state, feedid, session):
-        self._name = name
-        self.zone_state = zone_state
-        self.feedid = feedid
+    stats = {k: 0 for k in categories}
+    stats["total_active_alerts"] = 0
+
+    for alert in alerts:
+        if not alert.get("event"):
+            continue
+        event_text = alert["event"].lower()
+        if is_active(alert):
+            stats["total_active_alerts"] += 1
+            for k, substr in categories.items():
+                if substr in event_text:
+                    stats[k] += 1
+    return stats
+
+class WeatherAlertsCoordinator(DataUpdateCoordinator):
+    """Coordinator for fetching weather alerts and tracking alert_tracking."""
+
+    def __init__(self, hass, session, feedid, config_entry_id, update_interval):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"WeatherAlerts ({feedid})",
+            update_interval=update_interval,
+        )
         self.session = session
-        self._state = 0
-        self.connected = True
-        self.exception = None
-        self._attr = {}
+        self.feedid = feedid
+        self.config_entry_id = config_entry_id
+        self._last_good_data = None
+        self._last_error = []
+        self._alert_tracking_list = []
+        _LOGGER.info("weatheralerts: WeatherAlertsCoordinator initialized for feedid: %s", feedid)
 
-    async def async_update(self):
-        """Run update."""
-        alerts = []
+    async def _async_update_data(self):
+        _LOGGER.debug("weatheralerts: _async_update_data called for feedid: %s", self.feedid)
+        update_error = []
+
+        entry = next((e for e in self.hass.config_entries.async_entries(DOMAIN)
+                     if e.entry_id == self.config_entry_id), None)
+        timeout_seconds = entry.options.get(CONF_API_TIMEOUT,
+                            entry.data.get(CONF_API_TIMEOUT, DEFAULT_API_TIMEOUT)) if entry else DEFAULT_API_TIMEOUT
 
         try:
-            async with async_timeout.timeout(10):
-                response = await self.session.get(URL.format(self.feedid))
+            async with async_timeout.timeout(timeout_seconds):
+                alerts_url = ALERTS_API.format(self.feedid)
+                _LOGGER.debug("weatheralerts: Fetching Alerts URL: %s", alerts_url)
+                response = await self.session.get(alerts_url, headers=HEADERS)
+                _LOGGER.debug("weatheralerts: HTTP status code: %s", response.status)
                 if response.status != 200:
-                    self._state = "unavailable"
-                    _LOGGER.warning(
-                        "[%s] Possible API outage. Currently unable to download from weather.gov - HTTP status code %s",
-                        self.feedid,
-                        response.status
-                    )
-                else:
-                    data = await response.json()
-
-                    if data.get("features") is not None:
-                        for alert in data["features"]:
-                            if alert.get("properties") is not None:
-                                properties = alert["properties"]
-                                if properties["ends"] is None:
-                                    properties["endsExpires"] = properties.get("expires", "null")
-                                else:
-                                    properties["endsExpires"] = properties.get("ends", "null")
-                                alerts.append(
-                                    {
-                                        "area": properties.get("areaDesc", "null"),
-                                        "certainty": properties.get("certainty", "null"),
-                                        "description": properties.get("description", "null"),
-                                        "ends": properties.get("ends", "null"),
-                                        "event": properties.get("event", "null"),
-                                        "instruction": properties.get("instruction", "null"),
-                                        "response": properties.get("response", "null"),
-                                        "sent": properties.get("sent", "null"),
-                                        "severity": properties.get("severity", "null"),
-                                        "title": properties.get("headline", "null").split(" by ")[0],
-                                        "urgency": properties.get("urgency", "null"),
-                                        "NWSheadline": properties["parameters"].get("NWSheadline", "null"),
-                                        "hailSize": properties["parameters"].get("hailSize", "null"),
-                                        "windGust": properties["parameters"].get("windGust", "null"),
-                                        "waterspoutDetection": properties["parameters"].get("waterspoutDetection", "null"),
-                                        "effective": properties.get("effective", "null"),
-                                        "expires": properties.get("expires", "null"),
-                                        "endsExpires": properties.get("endsExpires", "null"),
-                                        "onset": properties.get("onset", "null"),
-                                        "status": properties.get("status", "null"),
-                                        "messageType": properties.get("messageType", "null"),
-                                        "category": properties.get("category", "null"),
-                                        "sender": properties.get("sender", "null"),
-                                        "senderName": properties.get("senderName", "null"),
-                                        "id": properties.get("id", "null"),
-                                        "zoneid": self.feedid,
-                                    }
-                                )
-                    alerts.sort(key=lambda x: (x['id']), reverse=True)
-
-                    for sorted_alert in alerts:
-                        _LOGGER.debug(
-                            "[%s] Sorted alert ID: %s",
-                            self.feedid,
-                            sorted_alert.get("id", "null")
-                        )
-
-                    self._state = len(alerts)
-                    self._attr = {
-                        "alerts": alerts,
-                        "integration": "weatheralerts",
-                        "state": self.zone_state,
-                        "zone": self.feedid,
+                    error_msg = f"Possible API outage (status {response.status})"
+                    current_entry = {
+                        "type": "http_error",
+                        "status": response.status,
+                        "message": error_msg,
+                        "timestamp": dt_util.now().isoformat(),
                     }
-        except Exception:  # pylint: disable=broad-except
-            self.exception = sys.exc_info()[0].__name__
-            connected = False
+                    previous_entry = next((e for e in reversed(self._last_error) if e.get("type") == "success"), None)
+                    update_error = [current_entry]
+                    if previous_entry:
+                        update_error.append(previous_entry)
+                    if self._last_good_data:
+                        data = dict(self._last_good_data)
+                        data["error"] = update_error
+                        self._last_error = update_error
+                        return data
+                    else:
+                        return {
+                            "alerts": [],
+                            "count": 0,
+                            "alert_stats": {},
+                            "integration": "weatheralerts",
+                            "zone": self.feedid,
+                            "alert_tracking": self._alert_tracking_list,
+                            "error": update_error,
+                        }
+                data = await response.json()
+                _LOGGER.debug("weatheralerts: Fetched data keys: %s", list(data.keys()))
+        except Exception as err:
+            error_msg = f"Update failed: {err}"
+            current_entry = {
+                "type": "exception",
+                "status": "",
+                "message": str(err),
+                "timestamp": dt_util.now().isoformat(),
+            }
+            previous_entry = next((e for e in reversed(self._last_error) if e.get("type") == "success"), None)
+            update_error = [current_entry]
+            if previous_entry:
+                update_error.append(previous_entry)
+            _LOGGER.debug("weatheralerts: Exception in _async_update_data: %s", err)
+            if self._last_good_data:
+                data = dict(self._last_good_data)
+                data["error"] = update_error
+                self._last_error = update_error
+                return data
+            else:
+                return {
+                    "alerts": [],
+                    "count": 0,
+                    "alert_stats": {},
+                    "integration": "weatheralerts",
+                    "zone": self.feedid,
+                    "alert_tracking": self._alert_tracking_list,
+                    "error": update_error,
+                }
+
+        # Get config entry options
+        entry = None
+        if hasattr(self.hass, "config_entries"):
+            for e in self.hass.config_entries.async_entries(DOMAIN):
+                if e.entry_id == self.config_entry_id:
+                    entry = e
+                    break
+        entry_options = entry.options if entry else None
+
+        # Build alerts list as before
+        alerts = []
+        for feature in data.get("features", []):
+            props = feature.get("properties", {})
+            props["endsExpires"] = (
+                props.get("expires", "null")
+                if props.get("ends") is None
+                else props.get("ends", "null")
+            )
+            event_value = props.get("event", "null")
+            alert = {
+                "area": props.get("areaDesc", "null"),
+                "certainty": props.get("certainty", "null"),
+                "description": props.get("description", "null"),
+                "ends": props.get("ends", "null"),
+                "event": event_value,
+                "instruction": props.get("instruction", "null"),
+                "response": props.get("response", "null"),
+                "sent": props.get("sent", "null"),
+                "severity": props.get("severity", "null"),
+                "title": props.get("headline", "null").split(" by ")[0],
+                "urgency": props.get("urgency", "null"),
+                "NWSheadline": props.get("NWSheadline", "null"),
+                "hailSize": props.get("hailSize", "null"),
+                "windGust": props.get("windGust", "null"),
+                "waterspoutDetection": props.get("waterspoutDetection", "null"),
+                "effective": props.get("effective", "null"),
+                "expires": props.get("expires", "null"),
+                "onset": props.get("onset", "null"),
+                "endsExpires": props.get("endsExpires", "null"),
+                "status": props.get("status", "null"),
+                "messageType": props.get("messageType", "null"),
+                "category": props.get("category", "null"),
+                "sender": props.get("sender", "null"),
+                "senderName": props.get("senderName", "null"),
+                "id": props.get("id", "null"),
+                "zoneid": self.feedid,
+            }
+            alert["icon"] = _get_icon_for_event(event_value, entry_options)
+            alerts.append(alert)
+        _LOGGER.debug("weatheralerts: Parsed %d alerts", len(alerts))
+
+        alerts.sort(key=lambda x: (x.get("sent", ""), x.get("id", "")), reverse=True)
+        alert_stats = _compute_active_alert_stats(alerts)
+
+        # ------- alert_tracking TRACKING LOGIC -------
+        now = dt_util.now()
+        one_hour_ago = now - timedelta(hours=1)
+
+        # 1. Build lookups for current and previous
+        current_alerts_by_id = {a["id"]: a for a in alerts if a.get("id")}
+        prev_alerts_by_id = {e["id"]: e for e in self._alert_tracking_list if "id" in e}
+
+        # 2. Build new alert_tracking list
+        new_alert_tracking_list = []
+        is_initial = not self._alert_tracking_list
+        for alert_tracking, alert in current_alerts_by_id.items():
+            expires = alert.get("expires")
+            sent = alert.get("sent")
+            prev_entry = prev_alerts_by_id.get(alert_tracking)
+            if is_initial or prev_entry is None:
+                status = "new"
+            else:
+                # if it existed before—even if it was “delete”—treat as “old”
+                status = "old"
+
+            new_alert_tracking_list.append({
+                "id": alert_tracking,
+                "sent": sent,
+                "expires": expires,
+                "status": status,
+            })
+
+        # 3. Mark as deleted if missing from live alerts
+        for alert_tracking, prev_entry in prev_alerts_by_id.items():
+            if alert_tracking not in current_alerts_by_id and prev_entry.get("status") != "delete":
+                new_alert_tracking_list.append({
+                    "id": alert_tracking,
+                    "sent": prev_entry.get("sent"),
+                    "expires": prev_entry.get("expires"),
+                    "status": "delete",
+                })
+
+        # 4. Remove deleted+expired entries (>1hr after expires)
+        cleaned_alert_tracking_list = []
+        for entry in new_alert_tracking_list:
+            if entry["status"] == "delete":
+                expires = entry.get("expires")
+                try:
+                    exp_dt = dt_util.parse_datetime(expires)
+                except Exception:
+                    exp_dt = None
+                if exp_dt is not None and exp_dt > one_hour_ago:
+                    cleaned_alert_tracking_list.append(entry)
+            else:
+                cleaned_alert_tracking_list.append(entry)
+
+        cleaned_alert_tracking_list.sort(key=lambda x: (x.get("sent", ""), x.get("id", "")), reverse=True)
+        self._alert_tracking_list = cleaned_alert_tracking_list
+        # ------- END alert_tracking TRACKING LOGIC -------
+
+        # Build success + last failure error tracking
+        current_entry = {
+            "type": "success",
+            "status": "OK",
+            "message": "no errors",
+            "timestamp": dt_util.now().isoformat(),
+        }
+        previous_entry = next((e for e in reversed(self._last_error) if e.get("type") != "success"), None)
+        update_error = [current_entry]
+        if previous_entry:
+            update_error.append(previous_entry)
+
+        result = {
+            "alerts": alerts,
+            "count": len(alerts),
+            "alert_stats": alert_stats,
+            "integration": "weatheralerts",
+            "zone": self.feedid,
+            "alert_tracking": self._alert_tracking_list,
+            "error": update_error,
+        }
+        self._last_good_data = dict(result)
+        self._last_error = update_error
+        _LOGGER.debug("weatheralerts: Returning update data: count=%d", len(alerts))
+        return result
+
+# ------------ RestoreEntity ADDED! ------------
+class WeatherAlertsSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+    """Representation of a weather alerts sensor with persistence."""
+
+    def __init__(self, coordinator, entity_name, feedid):
+        if not entity_name:
+            entity_name = f"weatheralerts_{_clean_for_entity_id(feedid)}"
+            _LOGGER.debug("weatheralerts: entity_name missing, using fallback %s", entity_name)
         else:
-            connected = True
-        finally:
-            # Handle connection messages here.
-            if self.connected:
-                if not connected:
-                    self._state = "unavailable"
-                    _LOGGER.warning(
-                        "[%s] Could not update the sensor (%s)",
-                        self.feedid,
-                        self.exception,
-                    )
+            entity_name = _clean_for_entity_id(entity_name)
+        _LOGGER.debug("weatheralerts: WeatherAlertsSensor __init__ for %s", entity_name)
+        super().__init__(coordinator)
+        self.entity_id = f"sensor.{entity_name}"
+        self._feedid = feedid
+        self._attr_name = None
 
-            elif not self.connected:
-                if connected:
-                    _LOGGER.info("[%s] Update of the sensor completed", self.feedid)
-                else:
-                    self._state = "unavailable"
-                    _LOGGER.warning(
-                        "[%s] Still no update (%s)", self.feedid, self.exception
-                    )
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self._update_friendly_name()
+        entry = self._get_config_entry()
+        if entry:
+            self.async_on_remove(
+                entry.add_update_listener(self._config_entry_updated)
+            )
+        # ------------- Restore alert_tracking after restart -------------
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            restored_alert_tracking = last_state.attributes.get("alert_tracking")
+            if restored_alert_tracking and isinstance(self.coordinator, WeatherAlertsCoordinator):
+                self.coordinator._alert_tracking_list = restored_alert_tracking
+                _LOGGER.info("weatheralerts: Restored alert_tracking list from last state")
+        # ----------------------------------------------------------
 
-            self.connected = connected
+    async def _config_entry_updated(self, hass, entry):
+        self._update_friendly_name()
+        self.async_write_ha_state()
+
+    def _get_config_entry(self):
+        if hasattr(self.coordinator, "config_entry_id"):
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.entry_id == self.coordinator.config_entry_id:
+                    return entry
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        return entries[0] if entries else None
+
+    def _update_friendly_name(self):
+        entry = self._get_config_entry()
+        if entry:
+            self._attr_name = entry.data.get(CONF_NAME, self._attr_name)
+            _LOGGER.debug("weatheralerts: Updated friendly name to: %s", self._attr_name)
 
     @property
     def name(self):
-        """Return the name."""
-        return self._name
+        return self._attr_name
 
     @property
     def unique_id(self):
-        """Return a unique ID to use for this sensor."""
-        return f"weatheralerts_{self.feedid}".replace(",", "")
+        uid = f"weatheralerts_{self._feedid.replace(',', '').lower()}"
+        _LOGGER.debug("weatheralerts: WeatherAlertsSensor unique_id: %s", uid)
+        return uid
 
     @property
     def state(self):
-        """Return the state."""
-        return self._state
+        if self.coordinator.data:
+            _LOGGER.debug("weatheralerts: WeatherAlertsSensor state: %s", self.coordinator.data.get('count', None))
+            return self.coordinator.data.get("count", None)
+        _LOGGER.debug("weatheralerts: WeatherAlertsSensor state: coordinator.data is None")
+        return None
 
     @property
     def unit_of_measurement(self):
-        """Return the unit_of_measurement."""
         return "Alerts"
 
     @property
     def icon(self):
-        """Return icon."""
         return "mdi:alert-octagram"
 
     @property
     def extra_state_attributes(self):
-        """Return attributes."""
-        return self._attr
+        if self.coordinator.data:
+            _LOGGER.debug("weatheralerts: WeatherAlertsSensor extra_state_attributes: %s", self.coordinator.data)
+            entry = self._get_config_entry()
+            zone_name = (
+                entry.options.get(CONF_ZONE_NAME)
+                or entry.data.get(CONF_ZONE_NAME)
+                or None
+            )
+            return {
+                "integration": self.coordinator.data["integration"],
+                "zone": self.coordinator.data["zone"],
+                "zone_name": zone_name,
+                "alert_stats": self.coordinator.data.get("alert_stats", {}),
+                "alerts": self.coordinator.data["alerts"],
+                "alert_tracking": self.coordinator.data.get("alert_tracking", []),
+                "error": self.coordinator.data.get("error", []),
+            }
+        _LOGGER.debug("weatheralerts: WeatherAlertsSensor extra_state_attributes: coordinator.data is None")
+        return {}
+
+async def async_setup_entry(hass, entry, add_entities):
+    _LOGGER.debug("weatheralerts: async_setup_entry (sensor.py) called for entry: %s", entry.entry_id)
+    zone = entry.options.get(CONF_ZONE, entry.data.get(CONF_ZONE, ""))
+    county = entry.options.get(CONF_COUNTY, entry.data.get(CONF_COUNTY, ""))
+    marine_zones = entry.options.get(CONF_MARINE_ZONES, entry.data.get(CONF_MARINE_ZONES, ""))
+    conf_name = entry.data.get(CONF_NAME, "NWS Weather Alerts")
+    entity_name = entry.data.get(CONF_ENTITY_NAME)
+    parts = [zone]
+    if county:
+        parts.append(county)
+    if marine_zones:
+        parts += [z.strip() for z in marine_zones.split(",") if z.strip()]
+    feedid = ",".join(parts)
+    if not entity_name:
+        entity_name = f"weatheralerts_{_clean_for_entity_id(feedid)}"
+        _LOGGER.debug("weatheralerts: entity_name missing in setup_entry! Using fallback %s", entity_name)
+    _LOGGER.debug(
+        "weatheralerts: async_setup_entry (sensor.py): zone=%s, county=%s, marine_zones=%s, entity_name=%s, friendly_name=%s, feedid=%s",
+        zone, county, marine_zones, entity_name, conf_name, feedid
+    )
+    session = async_get_clientsession(hass)
+    update_interval_sec = entry.options.get(CONF_UPDATE_INTERVAL, entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
+    update_interval = timedelta(seconds=update_interval_sec)
+    coordinator = WeatherAlertsCoordinator(
+        hass, session, feedid, entry.entry_id, update_interval=update_interval
+    )
+    await coordinator.async_config_entry_first_refresh()
+    _LOGGER.debug("weatheralerts: async_setup_entry (sensor.py): finished first refresh")
+    add_entities([WeatherAlertsSensor(coordinator, entity_name, feedid)], True)
+    _LOGGER.info("weatheralerts: async_setup_entry (sensor.py): sensor entity added (%s)", entity_name)
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    _LOGGER.warning(
+        "weatheralerts: YAML configuration for weatheralerts is deprecated and no longer supported; "
+        "please use the Home Assistant UI to set up the integration. "
+        "See the documentation for migration details."
+    )
+    return True

--- a/custom_components/weatheralerts/sensor.py
+++ b/custom_components/weatheralerts/sensor.py
@@ -127,10 +127,11 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, entry, add_entities):
     """Set up sensors from config entry."""
+    # Load configuration from entry options if available, else use initial data
     config = {
-        CONF_STATE: entry.data[CONF_STATE],
-        CONF_ZONE: entry.data[CONF_ZONE],
-        CONF_COUNTY: entry.data.get(CONF_COUNTY, ""),
+        CONF_STATE: entry.options.get(CONF_STATE, entry.data[CONF_STATE]),
+        CONF_ZONE: entry.options.get(CONF_ZONE, entry.data[CONF_ZONE]),
+        CONF_COUNTY: entry.options.get(CONF_COUNTY, entry.data.get(CONF_COUNTY, "")),
     }
     return await _async_setup(hass, config, add_entities)
 


### PR DESCRIPTION
Adds config flow that uses latitude/longitude for automatic zone and county code configuration. Codes can be overridden during config. Marine codes can also be added during config. Once configured, using the config (reconfig) option via the UI will allow the sensor to be reconfigured and also allow icon definitions to be changed. The sensor has alert icon added to each alert in the alerts array, an alert tracking array can be used for smarter automation triggering, an error array can be used to track when the sensor is not working (or when it was last working/not working), and an alert stats array to track active alert count for each alert category.