### PR TITLE
Fix NWSheadline extraction from properties

### DIFF
--- a/custom_components/weatheralerts/sensor.py
+++ b/custom_components/weatheralerts/sensor.py
@@ -346,7 +346,7 @@ class WeatherAlertsCoordinator(DataUpdateCoordinator):
                 "severity": props.get("severity", "null"),
                 "title": props.get("headline", "null").split(" by ")[0],
                 "urgency": props.get("urgency", "null"),
-                "NWSheadline": props.get("NWSheadline", "null"),
+                "NWSheadline": props.get("parameters", {}).get("NWSheadline", ["null"])[0],
                 "hailSize": props.get("hailSize", "null"),
                 "windGust": props.get("windGust", "null"),
                 "waterspoutDetection": props.get("waterspoutDetection", "null"),

--- a/custom_components/weatheralerts/sensor.py
+++ b/custom_components/weatheralerts/sensor.py
@@ -346,7 +346,7 @@ class WeatherAlertsCoordinator(DataUpdateCoordinator):
                 "severity": props.get("severity", "null"),
                 "title": props.get("headline", "null").split(" by ")[0],
                 "urgency": props.get("urgency", "null"),
-                "NWSheadline": props.get("parameters", {}).get("NWSheadline", ["null"])[0],
+                "NWSheadline": props.get("parameters", {}).get("NWSheadline", "null"),
                 "hailSize": props.get("hailSize", "null"),
                 "windGust": props.get("windGust", "null"),
                 "waterspoutDetection": props.get("waterspoutDetection", "null"),


### PR DESCRIPTION
After a recent change, the NWSHeadline is no longer being populated. The NWSHeadline is available as a list of strings under the "parameters" section of the "properties" in the API. I am open to suggestions on if the default should be a "null" string and if only the first entry is the one that matters. Not sure if there are typically more than one entry but in the few sample API outputs that I looked at, it was a list of a single element.

Example API response:
```json
"parameters": {
    "AWIPSidentifier": [
        "RFWDMX"
    ],
    "WMOidentifier": [
        "WWUS83 KDMX 271652"
    ],
    "NWSheadline": [
        "RED FLAG WARNING REMAINS IN EFFECT UNTIL 9 PM CDT THIS EVENING FOR CRITICAL FIRE WEATHER CONDITIONS FOR SOUTHWEST TO WEST CENTRAL IOWA"
    ],
    "BLOCKCHANNEL": [
        "EAS",
        "NWEM",
        "CMAS"
    ],
    "VTEC": [
        "/O.CON.KDMX.FW.W.0005.260327T1700Z-260328T0200Z/"
    ],
    "eventEndingTime": [
        "2026-03-27T21:00:00-05:00"
    ],
    "expiredReferences": [
        "w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.7feecdc973c454386d5d96c069283bfb1abc6740.001.1,2026-03-27T03:00:00-05:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.1113ce95669911b237d61e4cec5831d9fb8fd013.001.1,2026-03-26T21:56:00-05:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.420e3c139a909c0e3e9293c739a4d8d6a9d0a6e7.001.1,2026-03-26T13:42:00-05:00"
    ]
}
```